### PR TITLE
Revert "Make exponent-notation in decNumberToString optional"

### DIFF
--- a/decNumber.c
+++ b/decNumber.c
@@ -3718,9 +3718,7 @@ decNumber * decNumberZero(decNumber *dn) {
 // invalid.
 static void decToString(const decNumber *dn, char *string, Flag eng) {
   Int exp=dn->exponent;       // local copy
-#ifndef DECSTRING_NO_EXPONENT
   Int e;                      // E-part value
-#endif // DECSTRING_NO_EXPONENT
   Int pre;                    // digits before the '.'
   Int cut;                    // for counting digits in a Unit
   char *c=string;             // work [output pointer]
@@ -3770,7 +3768,6 @@ static void decToString(const decNumber *dn, char *string, Flag eng) {
 
   /* non-0 exponent -- assume plain form */
   pre=dn->digits+exp;              // digits before '.'
-#ifndef DECSTRING_NO_EXPONENT
   e=0;                             // no E
   if ((exp>0) || (pre<-5)) {       // need exponential form
     e=exp+dn->digits-1;            // calculate E value
@@ -3799,7 +3796,6 @@ static void decToString(const decNumber *dn, char *string, Flag eng) {
         } // zero
       } // eng
     } // need exponent
-#endif // DECSTRING_NO_EXPONENT
 
   /* lay out the digits of the coefficient, adding 0s and . as needed */
   u=*up;
@@ -3843,7 +3839,6 @@ static void decToString(const decNumber *dn, char *string, Flag eng) {
       }
     }
 
-#ifndef DECSTRING_NO_EXPONENT
   /* Finally add the E-part, if needed.  It will never be 0, has a
      base maximum and minimum of +999999999 through -999999999, but
      could range down to -1999999998 for anormal numbers */
@@ -3864,7 +3859,6 @@ static void decToString(const decNumber *dn, char *string, Flag eng) {
       c++;                              // step for next
       } // cut
     }
-#endif // DECSTRING_NO_EXPONENT
   *c='\0';          // terminate the string (all paths)
   return;
   } // decToString

--- a/decNumber.h
+++ b/decNumber.h
@@ -50,11 +50,6 @@
   #if !defined(DECNUMDIGITS)
     #define DECNUMDIGITS 1
   #endif
-  /*
-   * Undefine the macro if you want to convert decNumber to string
-   * with exponent (e.g. "1.5e-6" instead of "0.0000015")
-   */
-  #define DECSTRING_NO_EXPONENT
 
   /* The size (integer data type) of each unit is determined by the   */
   /* number of digits it will hold.                                   */


### PR DESCRIPTION
Use scientific notation in printing again. See https://github.com/tarantool/tarantool/pull/11497 for details.

Required for https://github.com/tarantool/tarantool/pull/11497